### PR TITLE
Moved wsserver code completely to master

### DIFF
--- a/common/dtos/websocket_message.go
+++ b/common/dtos/websocket_message.go
@@ -1,5 +1,7 @@
 package dtos
 
+import "encoding/json"
+
 //WebSocketMessageType represents the type of the message.
 type WebSocketMessageType uint8
 
@@ -24,6 +26,21 @@ type WebSocketMessage struct {
 //WebSocketMessageMarshaller allows conversion from byte slices to WSMessage structs
 //and vice versa.
 type WebSocketMessageMarshaller interface {
-	Marshall(*WebSocketMessage) ([]byte, error)
-	Unmarshall([]byte) (*WebSocketMessage, error)
+	Marshall(WebSocketMessage) ([]byte, error)
+	Unmarshall([]byte) (WebSocketMessage, error)
+}
+
+//JSONMessageMarshaller is the default WebSocketMessageMarshaller - uses JSON as the target format
+type JSONMessageMarshaller struct{}
+
+//Marshall encodes a WebSocketMessage as a JSON object
+func (j JSONMessageMarshaller) Marshall(msg WebSocketMessage) (buf []byte, err error) {
+	buf, err = json.Marshal(msg)
+	return
+}
+
+//Unmarshall decodes a JSON object to a WebSocketMessage
+func (JSONMessageMarshaller) Unmarshall(buf []byte) (msg WebSocketMessage, err error) {
+	err = json.Unmarshal(buf, msg)
+	return
 }

--- a/common/wsserver/authenticator.go
+++ b/common/wsserver/authenticator.go
@@ -1,14 +1,9 @@
 package wsserver
 
-import (
-	"net"
-
-	"github.com/djarek/btrfs-volume-manager/common/dtos"
-)
+import "net"
 
 //WebSocketAuthenticator represents an object used for authentication of a newly
 //connected websocket client.
 type WebSocketAuthenticator interface {
-	GetChallenge(net.Addr) *dtos.WebSocketMessage
-	VerifyChallengeResponse(net.Addr, *dtos.WebSocketMessage) error
+	Authenticate(net.Addr, []byte) ([]byte, error)
 }

--- a/master/parser.go
+++ b/master/parser.go
@@ -1,0 +1,14 @@
+package main
+
+import "github.com/djarek/btrfs-volume-manager/common/dtos"
+
+/*messageParser parses the received WebSocketMessage and dispatches appropriate
+handler functions. Implements the RecvMessageParser interface.
+*/
+type messageParser struct{}
+
+/*ParseRecvMsg parses the received WebSocketMessage and dispatches appropriate
+handler functions. */
+func (mp messageParser) ParseRecvMsg(dtos.WebSocketMessage) error {
+	return nil
+}

--- a/master/views/index.html
+++ b/master/views/index.html
@@ -41,7 +41,7 @@
 		document.getElementById("iPassword").addEventListener("keydown", clickEnter);
 		document.getElementById("btLogin").addEventListener("click", Login);
 
-		var socket = new WebSocket("ws://localhost/auth"),
+		var socket = new WebSocket("ws://localhost:8080/ws"),
 				container = document.getElementById("container");
 
 		function clickEnter()
@@ -58,7 +58,7 @@
 				"Password": document.getElementById("iPassword").value
 			}));
 			socket.onmessage = function (e) {
-				if(e.data == "true"){
+				if(e.data == "auth_ok"){
 					location.href = window.location.href.concat("content.html")
 				} else {
 					document.getElementById("iName").value = "";

--- a/slave/main.go
+++ b/slave/main.go
@@ -2,49 +2,10 @@ package main
 
 import (
 	"fmt"
-	"log"
-	"net"
-	"net/http"
 
-	"github.com/djarek/btrfs-volume-manager/common/dtos"
-	"github.com/djarek/btrfs-volume-manager/common/wsserver"
 	"github.com/djarek/btrfs-volume-manager/slave/osinterface"
 )
 
-type testMarshaller struct {
-}
-
-func (tm testMarshaller) Marshall(wsMsg *dtos.WebSocketMessage) ([]byte, error) {
-	return []byte("test"), nil
-}
-
-func (tm testMarshaller) Unmarshall(buffer []byte) (*dtos.WebSocketMessage, error) {
-	fmt.Println(buffer)
-	return &dtos.WebSocketMessage{}, nil
-}
-
-type testAuthenticator struct{}
-
-func (ta testAuthenticator) GetChallenge(net.Addr) *dtos.WebSocketMessage {
-	return nil
-}
-
-func (ta testAuthenticator) VerifyChallengeResponse(net.Addr, *dtos.WebSocketMessage) error {
-	return nil
-}
-
-type testParser struct{}
-
-func (tp testParser) ParseRecvMsg(*dtos.WebSocketMessage) error {
-	return nil
-}
-
 func main() {
-	marshaller := &testMarshaller{}
-	parser := &testParser{}
-	authenticator := &testAuthenticator{}
-	cm := wsserver.NewConnectionManager(marshaller, parser, authenticator)
-	http.HandleFunc("/ws", cm.HandleWSConnection)
 	fmt.Print(osinterface.BlockDeviceCache.RescanBlockDevs())
-	log.Fatalln(http.ListenAndServe("127.0.0.1:8080", nil))
 }


### PR DESCRIPTION
It has been decided that the slaves will no longer host a websocket server to simplify the system architecture. The master-control's code has been adapted to use the wsserver websocket server implementation. Some wsserver code has been modified to better fit the new architecture.