### PR TITLE
Deleted env_var_setup.sh

### DIFF
--- a/env_var_setup.sh
+++ b/env_var_setup.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-export CGO_CFLAGS="-I"$(pwd)"/libbtrfs"
-export CGO_LDFLAGS="-L"$(pwd)"/libbtrfs/build"
-
-


### PR DESCRIPTION
This script is no longer necessary because the libbtrfs library was removed.