### PR TITLE
Fixed Unmarshalling and Connection Close bug

### DIFF
--- a/common/dtos/websocket_message.go
+++ b/common/dtos/websocket_message.go
@@ -41,6 +41,6 @@ func (j JSONMessageMarshaller) Marshall(msg WebSocketMessage) (buf []byte, err e
 
 //Unmarshall decodes a JSON object to a WebSocketMessage
 func (JSONMessageMarshaller) Unmarshall(buf []byte) (msg WebSocketMessage, err error) {
-	err = json.Unmarshal(buf, msg)
+	err = json.Unmarshal(buf, &msg)
 	return
 }

--- a/common/wsserver/connection.go
+++ b/common/wsserver/connection.go
@@ -129,7 +129,7 @@ func (c *Connection) readerLoop() {
 	for {
 		_, msgBytes, err := c.wsConnection.ReadMessage()
 		if err != nil {
-			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway) {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure) {
 				log.Println("Error when reading websocket message: " + err.Error())
 			}
 			return


### PR DESCRIPTION
The message passed to the json.Unmarshal function was passed by value which caused it to return an error. The expected Close was invalidly set which caused wsserver to report an error when a normal connection close occured.