### PR TITLE
Refactor wsserver

### DIFF
--- a/common/wsserver/connection.go
+++ b/common/wsserver/connection.go
@@ -1,7 +1,9 @@
 package wsserver
 
 import (
+	"errors"
 	"log"
+	"sync"
 	"time"
 
 	"github.com/djarek/btrfs-volume-manager/common/dtos"
@@ -13,6 +15,7 @@ const (
 	pingInterval              = (pongTimeout * 9) / 10
 	writeTimeout              = 10 * time.Second
 	authenticationReadTimeout = writeTimeout
+	writeChannelSize          = 16
 )
 
 //SendCallback is the signature of the function that is called when an async
@@ -26,37 +29,32 @@ type RecvMessageParser interface {
 }
 
 type sendTask struct {
-	callback SendCallback
-	payload  []byte
+	callback    SendCallback
+	payload     []byte
+	messageType int
 }
 
 //Connection wraps the websocket connection
 type Connection struct {
 	wsConnection    *websocket.Conn
-	authenticated   bool
 	marshaller      dtos.WebSocketMessageMarshaller
 	parser          RecvMessageParser
 	onCloseCallback func()
-	pingTicker      *time.Ticker
 
 	writeChannel chan sendTask
+	closeOnce    sync.Once
 }
 
 func newConnection(wsConnection *websocket.Conn, marshaller dtos.WebSocketMessageMarshaller, parser RecvMessageParser) *Connection {
 	return &Connection{
-		wsConnection:  wsConnection,
-		authenticated: false,
-		marshaller:    marshaller,
-		parser:        parser,
+		wsConnection: wsConnection,
+		marshaller:   marshaller,
+		parser:       parser,
 
-		writeChannel: make(chan sendTask)}
+		writeChannel: make(chan sendTask, writeChannelSize)}
 }
 
-func (c *Connection) registerOnCloseCallback(cb func()) {
-	c.onCloseCallback = cb
-}
-
-//Authenticate performs authentication of the connection using the supplied authenticator.
+//authenticate performs authentication of the connection using the supplied authenticator.
 //It returns nil when the authentication is successful and the connection is ready to be
 //served.
 func (c *Connection) authenticate(authenticator WebSocketAuthenticator) (err error) {
@@ -72,8 +70,6 @@ func (c *Connection) authenticate(authenticator WebSocketAuthenticator) (err err
 	if err != nil {
 		log.Println("Error when authenticating: " + err.Error())
 	}
-
-	c.authenticated = true
 	return
 }
 
@@ -82,41 +78,8 @@ func (c *Connection) authenticate(authenticator WebSocketAuthenticator) (err err
 //Blocks until the reader loop exits, at which point the connection is properly
 //closed.
 func (c *Connection) Serve() {
-	if !c.authenticated {
-		log.Panicln("Serve called without valid authentication")
-	}
-
 	go c.writerLoop()
 	c.readerLoop()
-}
-
-func (c *Connection) writerLoop() {
-	c.pingTicker = time.NewTicker(pingInterval)
-	defer c.Close()
-
-	for {
-		select {
-		case <-c.pingTicker.C:
-			err := c.internalWrite(websocket.PingMessage, []byte{})
-			if err != nil {
-				log.Println("Error when sending websocket ping: " + err.Error())
-				return
-			}
-
-		case task := <-c.writeChannel:
-			err := c.internalWrite(websocket.TextMessage, task.payload)
-			task.callback(err)
-		}
-	}
-}
-
-func (c *Connection) internalWrite(msgType int, payload []byte) (err error) {
-	err = c.wsConnection.SetWriteDeadline(time.Now().Add(writeTimeout))
-	if err != nil {
-		return
-	}
-	err = c.wsConnection.WriteMessage(msgType, payload)
-	return
 }
 
 func (c *Connection) readerLoop() {
@@ -129,7 +92,8 @@ func (c *Connection) readerLoop() {
 	for {
 		_, msgBytes, err := c.wsConnection.ReadMessage()
 		if err != nil {
-			if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure) {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure) &&
+				websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway) {
 				log.Println("Error when reading websocket message: " + err.Error())
 			}
 			return
@@ -144,28 +108,102 @@ func (c *Connection) readerLoop() {
 	}
 }
 
-//Close closes the underlying connection and does the necessary cleanup
-//like removing the connection from the connection manager
-func (c *Connection) Close() error {
-	if c.pingTicker != nil {
-		c.pingTicker.Stop()
-	}
-	if c.onCloseCallback != nil {
-		c.onCloseCallback()
-	}
-	return c.wsConnection.Close()
+/*Close attempts to send a proper close to the client. If the connection
+is in an invalid state, this will fail, however, all the necessary cleanup
+will be performed properly anyway.*/
+func (c *Connection) Close() {
+	c.closeOnce.Do(func() {
+		c.addSendTask(sendTask{
+			callback:    func(error) {},
+			payload:     websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+			messageType: websocket.CloseMessage,
+		})
+	})
+}
+
+func (c *Connection) addSendTask(task sendTask) (err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			err = errors.New("Connection closed")
+			task.callback(err)
+		}
+	}()
+	c.writeChannel <- task
+	return
 }
 
 //SendAsync sends a WebSocketMessage asynchronously and returns immediately if an
 //error is encountered or the message write has been enqueued. If an error is
 //encountered during the network transfer, the error is passed to the callback
 func (c *Connection) SendAsync(msg dtos.WebSocketMessage, callback SendCallback) error {
-	webSocketMsgBytes, err := c.marshaller.Marshall(msg)
+	msgBytes, err := c.marshaller.Marshall(msg)
 	if err != nil {
 		log.Println("Error when marshalling WebSocketMessage: " + err.Error())
 		return err
 	}
 
-	c.writeChannel <- sendTask{callback, webSocketMsgBytes}
-	return nil
+	return c.addSendTask(sendTask{
+		callback:    callback,
+		payload:     msgBytes,
+		messageType: websocket.TextMessage,
+	})
+}
+
+func (c *Connection) writerLoop() {
+	pingTicker := time.NewTicker(pingInterval)
+	defer pingTicker.Stop()
+	defer c.internalClose()
+
+	for {
+		select {
+		case <-pingTicker.C:
+			err := c.internalWrite(websocket.PingMessage, []byte{})
+			if err != nil {
+				log.Println("Error when sending websocket ping: " + err.Error())
+				return
+			}
+
+		case task := <-c.writeChannel:
+			err := c.sendTask(task)
+			if err != nil || task.messageType == websocket.CloseMessage {
+				return
+			}
+		}
+	}
+}
+
+/*!!!!!! !!!!!!  !!!!!! DANGER !!!!!! !!!!!! !!!!!!
+The methods below are only supposed to be called by the writer goroutine
+*/
+
+func (c *Connection) flushRemainingTasks() {
+	for task := range c.writeChannel {
+		/*We ignore the error because we want to make sure the task owners are
+		notified about completion.*/
+		_ = c.sendTask(task)
+	}
+}
+
+func (c *Connection) internalClose() {
+	close(c.writeChannel)
+	c.flushRemainingTasks()
+
+	if c.onCloseCallback != nil {
+		c.onCloseCallback()
+	}
+	c.wsConnection.Close()
+}
+
+func (c *Connection) sendTask(task sendTask) error {
+	err := c.internalWrite(websocket.TextMessage, task.payload)
+	task.callback(err)
+	return err
+}
+
+func (c *Connection) internalWrite(msgType int, payload []byte) error {
+	err := c.wsConnection.SetWriteDeadline(time.Now().Add(writeTimeout))
+	if err != nil {
+		return err
+	}
+	return c.wsConnection.WriteMessage(msgType, payload)
 }

--- a/common/wsserver/connection.go
+++ b/common/wsserver/connection.go
@@ -41,7 +41,12 @@ type Connection struct {
 	closeOnce    sync.Once
 }
 
-func newConnection(wsConnection *websocket.Conn, marshaller dtos.WebSocketMessageMarshaller, parser RecvMessageParser) *Connection {
+func newConnection(
+	wsConnection *websocket.Conn,
+	marshaller dtos.WebSocketMessageMarshaller,
+	parser RecvMessageParser,
+) *Connection {
+
 	return &Connection{
 		wsConnection: wsConnection,
 		marshaller:   marshaller,

--- a/common/wsserver/connection.go
+++ b/common/wsserver/connection.go
@@ -73,11 +73,11 @@ func (c *Connection) authenticate(authenticator WebSocketAuthenticator) (err err
 	return
 }
 
-//Serve launches the reading and writing loops for this websocket connection.
+//serve launches the reading and writing loops for this websocket connection.
 //It must be called only after authentication is successful.
 //Blocks until the reader loop exits, at which point the connection is properly
 //closed.
-func (c *Connection) Serve() {
+func (c *Connection) serve() {
 	go c.writerLoop()
 	c.readerLoop()
 }

--- a/common/wsserver/connection_manager.go
+++ b/common/wsserver/connection_manager.go
@@ -76,5 +76,5 @@ func (cm *ConnectionManager) HandleWSConnection(w http.ResponseWriter, r *http.R
 
 	CID := cm.registerConnection(connection)
 	connection.onCloseCallback = func() { cm.unregisterConnection(CID) }
-	connection.Serve()
+	connection.serve()
 }

--- a/common/wsserver/connection_manager.go
+++ b/common/wsserver/connection_manager.go
@@ -56,7 +56,7 @@ func (cm *ConnectionManager) unregisterConnection(CID ConnectionID) {
 	delete(cm.connections, CID)
 }
 
-//HandleWSConnection handless the upgrade to a websocket connection and performs
+//HandleWSConnection handles the upgrade to a websocket connection and performs
 //authentication using the wsserver.WebSocketAuthenticator interface.
 //Satisfies the http.HandlerFunc interface.
 func (cm *ConnectionManager) HandleWSConnection(w http.ResponseWriter, r *http.Request) {
@@ -75,8 +75,6 @@ func (cm *ConnectionManager) HandleWSConnection(w http.ResponseWriter, r *http.R
 	}
 
 	CID := cm.registerConnection(connection)
-	connection.registerOnCloseCallback(func() {
-		cm.unregisterConnection(CID)
-	})
+	connection.onCloseCallback = func() { cm.unregisterConnection(CID) }
 	connection.Serve()
 }


### PR DESCRIPTION
Removed the authenticated variable from the Connection struct. Redesigned the connection closing flow, so that closing code is only called by the writer goroutine (internalClose() method). Calling that function would not make sense outside the websocket connection upgrade handler. Notification of the sender is now performed through a channel. This was done so that the writer goroutine does not execute foreign, potentially blocking code.