### PR TITLE
Websocket message serialization

### DIFF
--- a/common/dtos/websocket_message.go
+++ b/common/dtos/websocket_message.go
@@ -79,24 +79,6 @@ func (e Error) Error() string {
 	return e.Subsystem + " error: " + e.Details
 }
 
-/*NewErrorMsg constructs a WebSocketMessage from an error message*/
-func NewErrorMsg(subsystem string, err error, requestID int64) WebSocketMessage {
-	errStruct := Error{
-		Subsystem: subsystem,
-		Details:   err.Error(),
-	}
-	buf, err := json.Marshal(errStruct)
-	if err != nil {
-		log.Fatalln("Marshalling error message failed: " + err.Error())
-	}
-
-	return WebSocketMessage{
-		MessageType: WSMsgError,
-		Payload:     (*json.RawMessage)(&buf),
-		RequestID:   requestID,
-	}
-}
-
 var typeMap = make(map[WebSocketMessageType]reflect.Type)
 var reversedTypeMap = make(map[reflect.Type]WebSocketMessageType)
 

--- a/common/dtos/websocket_message.go
+++ b/common/dtos/websocket_message.go
@@ -2,7 +2,10 @@ package dtos
 
 import (
 	"encoding/json"
+	"errors"
 	"log"
+	"reflect"
+	"strconv"
 )
 
 //WebSocketMessageType represents the type of the message.
@@ -27,7 +30,7 @@ const (
 type WebSocketMessage struct {
 	MessageType WebSocketMessageType `json:"messageType"`
 	RequestID   int64                `json:"requestID"`
-	Payload     *json.RawMessage     `json:"payload"`
+	Payload     interface{}          `json:"payload"`
 }
 
 //WebSocketMessageMarshaller allows conversion from byte slices to WSMessage structs
@@ -92,4 +95,64 @@ func NewErrorMsg(subsystem string, err error, requestID int64) WebSocketMessage 
 		Payload:     (*json.RawMessage)(&buf),
 		RequestID:   requestID,
 	}
+}
+
+var typeMap = make(map[WebSocketMessageType]reflect.Type)
+var reversedTypeMap = make(map[reflect.Type]WebSocketMessageType)
+
+func init() {
+	RegisterMessageType(WSMsgAuthenticationRequest, AuthenticationRequest{})
+	RegisterMessageType(WSMsgAuthenticationResponse, AuthenticationResponse{})
+	RegisterMessageType(WSMsgError, Error{})
+}
+
+/*RegisterMessageType registers the type for both marshalling and unmarshalling.
+This function is NOT thread-safe and should be preferably called in the init()
+function of a higher-level package.*/
+func RegisterMessageType(typeID WebSocketMessageType, payload interface{}) {
+	_, found := typeMap[typeID]
+	if found {
+		log.Panicf("Type(ID: %d, %v) already registered!  ", typeID, payload)
+	}
+	t := reflect.ValueOf(payload).Type()
+	typeMap[typeID] = t
+	reversedTypeMap[t] = typeID
+}
+
+/*NewWebSocketMessage constructs a WebSocketMessage and sets the appropriate
+messageType. If the payload type is not in the typemap the function will panic.*/
+func NewWebSocketMessage(requestID int64, p interface{}) WebSocketMessage {
+	v := reflect.ValueOf(p)
+	msgType, found := reversedTypeMap[v.Type()]
+	if !found {
+		log.Panicf("Unknown payload type (payload:%s)", v.Type().String())
+	}
+	return WebSocketMessage{
+		MessageType: msgType,
+		RequestID:   requestID,
+		Payload:     p,
+	}
+}
+
+/*UnmarshalJSON unmarshals the json string into a websocket message. If the
+message type is unknown or the string is malformed an error is returned.*/
+func (w *WebSocketMessage) UnmarshalJSON(data []byte) error {
+	temp := struct {
+		MessageType WebSocketMessageType `json:"messageType"`
+		RequestID   int64                `json:"requestID"`
+		PayloadData *json.RawMessage     `json:"payload"`
+	}{}
+	err := json.Unmarshal(data, &temp)
+	if err != nil {
+		return err
+	}
+
+	w.RequestID = temp.RequestID
+	w.MessageType = temp.MessageType
+	payloadType, found := typeMap[temp.MessageType]
+	if !found {
+		return errors.New("Unknown message type: " + strconv.Itoa(int(w.MessageType)))
+	}
+	w.Payload = reflect.New(payloadType).Interface()
+	return json.Unmarshal([]byte(*temp.PayloadData), w.Payload)
 }

--- a/common/dtos/websocket_message_test.go
+++ b/common/dtos/websocket_message_test.go
@@ -1,0 +1,53 @@
+package dtos
+
+import (
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWebsocketMessageUnmarshalling(t *testing.T) {
+	var msgTypeString = strconv.Itoa(WSMsgAuthenticationRequest)
+	var validJSON = "{\"messageType\":" + msgTypeString +
+		",\"payload\":{\"username\":\"username\", \"password\":\"password\"},\"requestID\":1}"
+
+	var msg WebSocketMessage
+	err := json.Unmarshal([]byte(validJSON), &msg)
+	assert.Nil(t, err, "JSON string: "+validJSON)
+
+	assert.EqualValues(t, WSMsgAuthenticationRequest, msg.MessageType,
+		"messageType should be WSMsgAuthenticationRequest: "+msgTypeString)
+
+	authReq := msg.Payload.(*AuthenticationRequest)
+	assert.EqualValues(t, "username", authReq.Username)
+	assert.EqualValues(t, "password", authReq.Password)
+}
+
+func TestWebsocketMessageNew(t *testing.T) {
+	const requestID = 1
+	msg := NewWebSocketMessage(requestID, AuthenticationRequest{})
+	assert.EqualValues(t, WSMsgAuthenticationRequest, msg.MessageType,
+		"messageType should be WSMsgAuthenticationRequest")
+
+	assert.EqualValues(t, requestID, msg.RequestID, "invalid ")
+}
+
+func TestWebsocketMessageNewPanic(t *testing.T) {
+	assert.Panics(t, func() {
+		_ = NewWebSocketMessage(0, struct{}{})
+	})
+}
+
+func TestWebsocketMessageMarshalling(t *testing.T) {
+	var msgTypeString = strconv.Itoa(WSMsgAuthenticationRequest)
+	var expectedJSON = "{\"messageType\":" + msgTypeString +
+		",\"requestID\":1,\"payload\":{\"username\":\"username\",\"password\":\"password\"}}"
+	msg := NewWebSocketMessage(1, AuthenticationRequest{"username", "password"})
+
+	buf, err := json.Marshal(msg)
+	assert.Nil(t, err)
+
+	assert.EqualValues(t, expectedJSON, string(buf))
+}

--- a/master/parser.go
+++ b/master/parser.go
@@ -41,24 +41,23 @@ func (mp messageParser) ParseRecvMsg(msg dtos.WebSocketMessage, connection *wspr
 var auth = authenticator{}
 
 func onAuthenticationRequest(msg dtos.WebSocketMessage, connection *wsprotocol.Connection) {
-	var credentials dtos.AuthenticationRequest
-	err := json.Unmarshal(*msg.Payload, &credentials)
-	if err != nil {
-		log.Println("Error when unmarshalling credentials: " + err.Error())
+	credentials, ok := msg.Payload.(*dtos.AuthenticationRequest)
+	if !ok {
+		log.Printf("Invalid payload type (typeID:%d, payload:%v)\n", msg.MessageType,
+			msg.Payload)
 		return
 	}
+
 	response := dtos.AuthenticationResponse{
 		Result: "auth_wrong",
 	}
-
-	authErr := auth.Authenticate(credentials)
+	authErr := auth.Authenticate(*credentials)
 	if authErr == nil {
 		response.Result = "auth_ok"
 	}
-	marshalPayload(&msg.Payload, response)
-	msg.MessageType = dtos.WSMsgAuthenticationResponse
 
-	channel, err := connection.SendAsync(msg)
+	responseMsg := dtos.NewWebSocketMessage(msg.RequestID, response)
+	channel, err := connection.SendAsync(responseMsg)
 	if err != nil && authErr == nil {
 		go func() {
 			err := <-channel

--- a/master/parser.go
+++ b/master/parser.go
@@ -1,20 +1,11 @@
 package main
 
 import (
-	"encoding/json"
 	"log"
 
 	"github.com/djarek/btrfs-volume-manager/common/dtos"
 	"github.com/djarek/btrfs-volume-manager/common/wsprotocol"
 )
-
-func marshalPayload(out **json.RawMessage, v interface{}) {
-	buf, err := json.Marshal(v)
-	if err != nil {
-		log.Fatalln(err)
-	}
-	*out = (*json.RawMessage)(&buf)
-}
 
 /*messageParser parses the received WebSocketMessage and dispatches appropriate
 handler functions. Implements the RecvMessageParser interface.

--- a/master/views/index.html
+++ b/master/views/index.html
@@ -60,7 +60,7 @@
 	}
 
 	var messageHandlers = {
-		10000 : onErrorMsg
+		10000 : onErrorMsg,
 		10001 : onAuthenticationResponse
 	};
 	function dispatchMessageHandler(message) {


### PR DESCRIPTION
WebSocketMessages will now store the payload as interface{} and be automatically marshalled and unmarshalled. This requires prior registering of the necessary types and typeIDs with the use of the RegisterMessageType function. The unmarshalling process uses reflection and the type stored in the type map to create a payload instance of the appropriate type.  	Added marshalling and unmarshalling tests.