### PR TITLE
Block dev rescan

### DIFF
--- a/master/storageservers/blockdevices/controller.go
+++ b/master/storageservers/blockdevices/controller.go
@@ -38,7 +38,6 @@ func (c *controller) onBlockDeviceListRequest(ctx *request.Context, msg dtos.Web
 	requestID, responseChannel := storageServCtx.NewRequest()
 	msg.RequestID = requestID
 	storageServCtx.SendAsync(msg)
-
 	go func() {
 		response, ok := <-responseChannel
 		if ok {

--- a/master/views/app/scripts/app.js
+++ b/master/views/app/scripts/app.js
@@ -192,24 +192,26 @@ angular
 
         if (authService.hasSessionCookie() && !authService.isAuthRequestSent()) {
           authService.sendReloginRequest().then(function() {
+            event.preventDefault();
             $state.transitionTo($rootScope.toState, $rootScope.toStateParams);
           })
           .catch(function(err) {
             //TODO: show error message
+            event.preventDefault();
             $state.transitionTo("login");
           });
         } else {
+          event.preventDefault();
           $state.transitionTo("login");
+
         }
-        event.preventDefault();
       } else if (toState.name === "login") {
         if (authService.isAuthenticated()) {
           event.preventDefault();
         } else if (authService.hasSessionCookie()) {
-          $state.transitionTo("dashboard.home");
           event.preventDefault();
+          $state.transitionTo("dashboard.home");
         }
-
       }
     });
   }]);

--- a/master/views/app/scripts/controllers/serverdetails.js
+++ b/master/views/app/scripts/controllers/serverdetails.js
@@ -1,9 +1,16 @@
 angular.module("sbAdminApp")
-  .controller("ServerDetailsCtrl", ["$scope", "StorageService",
-  function($scope, StorageService) {
-    StorageService.sendBlockDeviceListRequest().then(function(msg) {
+  .controller("ServerDetailsCtrl" ["$scope", "$stateParams", "StorageService",
+  function($scope, $stateParams, StorageService) {
+    StorageService.sendBlockDeviceListRequest($stateParams.id).then(function(msg) {
       $scope.blockDevices = msg.payload.blockDevices;
     }).catch(function(err) {
       $scope.errorMsg = err;
     });
+    $scope.rescanBlockDevices = function() {
+      StorageService.sendBlockDeviceRescanRequest($stateParams.id).then(function(msg) {
+        $scope.blockDevices = msg.payload.blockDevices;
+      }).catch(function(err) {
+        $scope.errorMsg = err;
+      })
+    };
   }])

--- a/master/views/app/scripts/controllers/serverdetails.js
+++ b/master/views/app/scripts/controllers/serverdetails.js
@@ -1,5 +1,5 @@
 angular.module("sbAdminApp")
-  .controller("ServerDetailsCtrl" ["$scope", "$stateParams", "StorageService",
+  .controller("ServerDetailsCtrl", ["$scope", "$stateParams", "StorageService",
   function($scope, $stateParams, StorageService) {
     StorageService.sendBlockDeviceListRequest($stateParams.id).then(function(msg) {
       $scope.blockDevices = msg.payload.blockDevices;

--- a/master/views/app/scripts/services/storage.js
+++ b/master/views/app/scripts/services/storage.js
@@ -11,4 +11,9 @@ angular.module("sbAdminApp")
       var req = WebsocketService.payloads.NewBlockDeviceListRequest(serverID);
       return WebsocketService.send(req, "BlockDeviceListResponse");
     }
+
+    this.sendBlockDeviceRescanRequest = function(serverID) {
+      var req = WebsocketService.payloads.NewBlockDeviceRescanRequest(serverID);
+      return WebsocketService.send(req, "BlockDeviceRescanResponse")
+    }
   }])

--- a/master/views/app/scripts/services/websocket.js
+++ b/master/views/app/scripts/services/websocket.js
@@ -129,6 +129,7 @@ angular.module('sbAdminApp')
   var recvMessageTypes = {
     10000 : "Error",
     10001 : "AuthenticationResponse",
+    10005 : "BlockDeviceRescanResponse",
     10006 : "StorageServerListResponse",
     10007 : "BlockDeviceListResponse"
   };
@@ -158,16 +159,23 @@ angular.module('sbAdminApp')
     };
   }
 
+  this.NewBlockDeviceRescanRequest = function(serverID) {
+    return {
+      serverID: serverID,
+      getMessageType: function() { return 5; }
+    };
+  }
+
   this.NewStorageServerListRequest = function(serverID) {
     return {
       serverID: serverID,
       getMessageType: function() { return 6; }
-    }
+    };
   }
 
   this.NewBlockDeviceListRequest = function() {
     return {
       getMessageType: function() { return 7; }
-    }
+    };
   }
 })

--- a/master/views/app/views/storage/serverstoragedetails.html
+++ b/master/views/app/views/storage/serverstoragedetails.html
@@ -11,6 +11,9 @@
         <div class="panel panel-default">
             <div class="panel-heading">
                 Block Devices
+                <button type="button" ng-click="rescanBlockDevices()" class="btn btn-primary btn-sm"><span class="glyphicon glyphicon-refresh"></span>
+                  Rescan
+                </button>
             </div>
             <!-- /.panel-heading -->
             <div class="panel-body">

--- a/master/views/bower.json
+++ b/master/views/bower.json
@@ -26,7 +26,7 @@
   },
   "resolutions": {
     "bootstrap": "~3.1.1",
-    "angular": "1.5.3"
+    "angular": "1.5.x"
   },
   "appPath": "app"
 }

--- a/slave/block_dev_controller.go
+++ b/slave/block_dev_controller.go
@@ -10,11 +10,35 @@ import (
 type blockDevController struct{}
 
 func (b *blockDevController) ExportHandlers(adder router.HandlerAdder) {
-	adder.AddHandler(dtos.WSMsgBlockDeviceListRequest, b.onBlockDeviceRescanRequest)
+	adder.AddHandler(dtos.WSMsgBlockDeviceListRequest, b.onBlockDeviceListRequest)
+	adder.AddHandler(dtos.WSMsgBlockDeviceRescanRequest, b.onBlockDeviceRescanRequest)
+}
+
+func filterBlockDevices(blockDevs []dtos.BlockDevice) []dtos.BlockDevice {
+	var filtered []dtos.BlockDevice
+	for _, bd := range blockDevs {
+		if len(bd.Type) > 0 {
+			filtered = append(filtered, bd)
+		}
+	}
+	return filtered
+}
+
+func (b blockDevController) onBlockDeviceListRequest(ctx *request.Context, msg dtos.WebSocketMessage) {
+	blockDevs := filterBlockDevices(osinterface.BlockDeviceCache.GetAll())
+	response := dtos.NewWebSocketMessage(msg.RequestID, &dtos.BlockDeviceListResponse{BlockDevices: blockDevs})
+	ctx.SendAsync(response)
 }
 
 func (b blockDevController) onBlockDeviceRescanRequest(ctx *request.Context, msg dtos.WebSocketMessage) {
-	blockDevs := osinterface.BlockDeviceCache.GetAll()
-	response := dtos.NewWebSocketMessage(msg.RequestID, &dtos.BlockDeviceListResponse{BlockDevices: blockDevs})
+	err := osinterface.BlockDeviceCache.Rescan()
+	if err != nil {
+		//TODO: send error
+		return
+	}
+
+	blockDevs := filterBlockDevices(osinterface.BlockDeviceCache.GetAll())
+
+	response := dtos.NewWebSocketMessage(msg.RequestID, &dtos.BlockDeviceRescanResponse{BlockDevices: blockDevs})
 	ctx.SendAsync(response)
 }

--- a/slave/main.go
+++ b/slave/main.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/djarek/btrfs-volume-manager/common/router"
 	"github.com/djarek/btrfs-volume-manager/common/wsprotocol"
-	"github.com/djarek/btrfs-volume-manager/slave/osinterface"
 )
 
 const (
@@ -23,7 +22,6 @@ func main() {
 	r := router.New()
 	auth := &authController{}
 	auth.ExportHandlers(r)
-	osinterface.BlockDeviceCache.Rescan()
 	bdCtrl := blockDevController{}
 	bdCtrl.ExportHandlers(r)
 	ctx, err := wsprotocol.DefaultDialer.Dial(masterControlURL, r)


### PR DESCRIPTION
The stateChangeStart event could enter into an infinite recuison if the user opened a new tab without logging out.  Added rescan button & filtering of the block device list. The list will no longer contain devices that aren't disks.

Signed-off-by: Damian Jarek <damian.jarek93@gmail.com>